### PR TITLE
Separating data reception from rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "autocfg"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,6 +161,27 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-epoch 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -703,19 +729,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rc_car"
-version = "0.1.0"
-dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "glium 0.25.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "image 0.22.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "imgui 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "imgui-glium-renderer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "imgui-winit-support 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ttf-noto-sans 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,16 +751,16 @@ name = "rusttype"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rusttype 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusttype 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rusttype"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "approx 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayvec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "stb_truetype 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -782,6 +795,20 @@ dependencies = [
 name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "sensorview"
+version = "0.1.0"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glium 0.25.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "image 0.22.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "imgui 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "imgui-glium-renderer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "imgui-winit-support 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ttf-noto-sans 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "shared_library"
@@ -1003,6 +1030,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "000444226fcff248f2bc4c7625be32c63caccfecc2723a2b9f78a7487a49c407"
 "checksum approx 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
 "checksum arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba"
+"checksum arrayvec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ead801bcb8843bc91ea0a028f95b786f39ce519b1738de4e74a2a393332c2a16"
 "checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
 "checksum backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)" = "690a62be8920ccf773ee00ef0968649b0e724cda8bd5b12286302b4ae955fdf5"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
@@ -1019,6 +1047,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 "checksum core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)" = "56790968ab1c8a1202a102e6de05fc6e1ec87da99e4e93e9a7d13efbfc1e95a9"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
+"checksum crossbeam 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2d818a4990769aac0c7ff1360e233ef3a41adcb009ebb2036bf6915eb0f6b23c"
+"checksum crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
 "checksum crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b18cd2e169ad86297e6bc0ad9aa679aee9daa4f19e8163860faf7c164e4f5a71"
 "checksum crossbeam-epoch 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fedcd6772e37f3da2a9af9bf12ebe046c0dfe657992377b4df982a2b54cd37a9"
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
@@ -1085,7 +1115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rusttype 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)" = "310942406a39981bed7e12b09182a221a29e0990f3e7e0c971f131922ed135d5"
-"checksum rusttype 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07c67d4df90dcc0296c39e293fa9cfbbd29def131a5a3ffb9bc671f8dc906942"
+"checksum rusttype 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6fa38506b5cbf2fb67f915e2725cb5012f1b9a785b0ab55c4733acda5f6554ef"
 "checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"
 "checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+crossbeam = "0.7"
 image = "0.22"
 imgui = "0.2"
 imgui-winit-support = "0.2"

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -1,0 +1,59 @@
+use byteorder::{LittleEndian, ReadBytesExt};
+use crossbeam::channel::Sender;
+use image::jpeg::JPEGDecoder;
+use image::ImageDecoder;
+use std::io::{self, Cursor, Read};
+use std::net::SocketAddr;
+use std::net::{TcpListener, TcpStream};
+
+pub struct Camera {
+    sender: Sender<CameraData>,
+}
+
+pub struct CameraData {
+    pub image_bytes: Vec<u8>,
+    pub width: u32,
+    pub height: u32,
+}
+
+impl Camera {
+    pub fn new(sender: Sender<CameraData>) -> Self {
+        Self { sender }
+    }
+
+    pub fn start(mut self, ip: SocketAddr) -> io::Result<()> {
+        let listener = TcpListener::bind(&ip).unwrap();
+        for stream in listener.incoming() {
+            self.handle_image_stream(stream?)?;
+        }
+        Ok(())
+    }
+
+    pub fn handle_image_stream(
+        &mut self,
+        mut stream: TcpStream,
+    ) -> io::Result<()> {
+        loop {
+            let size = stream.read_u32::<LittleEndian>()? as usize;
+            let mut bytes = vec![0; size];
+            stream.read_exact(&mut bytes[..])?;
+            let bytes = Cursor::new(bytes);
+            let decoder =
+                JPEGDecoder::new(bytes).expect("Couldn't make decoder");
+            let (width, height) = decoder.dimensions();
+            let image_bytes =
+                decoder.read_image().expect("Couldn't read image");
+            let camera_data = CameraData {
+                image_bytes,
+                width: width as u32,
+                height: height as u32,
+            };
+            self.sender.send(camera_data).map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::ConnectionAborted,
+                    "camera channel disconnected",
+                )
+            })?;
+        }
+    }
+}

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -21,6 +21,10 @@ impl Camera {
         Self { sender }
     }
 
+    /// Starts a TCP listener to receive data from the camera. This supports
+    /// multiple connections, though multiple connections aren't handled
+    /// correctly at the moment.
+    ///
     pub fn start(mut self, ip: SocketAddr) -> io::Result<()> {
         let listener = TcpListener::bind(&ip).unwrap();
         for stream in listener.incoming() {
@@ -29,6 +33,13 @@ impl Camera {
         Ok(())
     }
 
+    /// Receives bytes and decodes them to bytes. This function makes a couple
+    /// of assumptions:
+    ///
+    /// 1. This function assumes the data format of the Raspberry Pi Camera
+    ///    (which is a u32 containing the data length followed by n bytes).
+    /// 2. The data is assumed to be MJPEG.
+    ///
     pub fn handle_image_stream(
         &mut self,
         mut stream: TcpStream,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,178 +1,11 @@
-use crate::camera::CameraData;
-use crossbeam::{unbounded, Receiver};
-use glium::glutin::{self, Event, WindowEvent};
-use glium::{
-    backend::Facade,
-    texture::{ClientFormat, RawImage2d},
-    Texture2d,
-};
-use glium::{Display, Surface};
-use imgui::{
-    self, im_str, Condition, Context, FontConfig, FontSource, Image, TextureId,
-    Ui, Window,
-};
-use imgui_glium_renderer::Renderer;
-use imgui_winit_support::{HiDpiMode, WinitPlatform};
-use std::borrow::Cow;
-use std::io;
-use std::rc::Rc;
-use std::thread;
-
 mod camera;
+mod window;
 
-pub struct System {
-    pub events_loop: glutin::EventsLoop,
-    pub display: Display,
-    pub imgui: Context,
-    pub platform: WinitPlatform,
-    pub renderer: Renderer,
-    pub font_size: f32,
-}
-
-fn init() -> System {
-    let events_loop = glutin::EventsLoop::new();
-    let context = glutin::ContextBuilder::new().with_vsync(true);
-    let builder = glutin::WindowBuilder::new()
-        .with_dimensions(glutin::dpi::LogicalSize::new(1920f64, 1080f64));
-    let display = Display::new(builder, context, &events_loop)
-        .expect("Could not create display.");
-    let mut imgui = Context::create();
-    imgui.set_ini_filename(None);
-    let mut platform = WinitPlatform::init(&mut imgui);
-    {
-        let gl_window = display.gl_window();
-        let window = gl_window.window();
-        platform.attach_window(imgui.io_mut(), &window, HiDpiMode::Rounded);
-    }
-    let hidpi_factor = platform.hidpi_factor();
-    let font_size = (13.0 * hidpi_factor) as f32;
-    imgui.fonts().add_font(&[
-        FontSource::DefaultFontData {
-            config: Some(FontConfig {
-                size_pixels: font_size,
-                ..FontConfig::default()
-            }),
-        },
-        FontSource::TtfData {
-            data: ttf_noto_sans::REGULAR,
-            size_pixels: font_size,
-            config: Some(FontConfig {
-                rasterizer_multiply: 1.75,
-                ..FontConfig::default()
-            }),
-        },
-    ]);
-
-    imgui.io_mut().font_global_scale = (1.0 / hidpi_factor) as f32;
-
-    let renderer = Renderer::init(&mut imgui, &display)
-        .expect("Failed to initialize renderer");
-
-    System {
-        events_loop,
-        display,
-        imgui,
-        platform,
-        renderer,
-        font_size,
-    }
-}
-
-struct SensorData {
-    camera: Option<Receiver<CameraData>>,
-}
-
-impl SensorData {
-    pub fn new() -> Self {
-        Self { camera: None }
-    }
-}
-
-fn render(mut sensor_data: SensorData) {
-    let System {
-        mut events_loop,
-        display,
-        mut imgui,
-        mut platform,
-        mut renderer,
-        ..
-    } = init();
-
-    let gl_window = display.gl_window();
-    let window = gl_window.window();
-    let mut texture_id = None;
-    let mut run = true;
-
-    while run {
-        events_loop.poll_events(|event| {
-            platform.handle_event(imgui.io_mut(), &window, &event);
-
-            if let Event::WindowEvent { event, .. } = event {
-                if let WindowEvent::CloseRequested = event {
-                    run = false;
-                }
-            }
-        });
-
-        let io = imgui.io_mut();
-        platform
-            .prepare_frame(io, &window)
-            .expect("Failed to start frame.");
-        let ui = imgui.frame();
-        if let Some(ref mut camera) = sensor_data.camera {
-            render_camera(
-                &ui,
-                &display,
-                &mut renderer,
-                &camera.try_recv().ok(),
-                &mut texture_id,
-            );
-        }
-
-        let mut target = display.draw();
-        target.clear_color_srgb(0.8, 0.8, 0.8, 1.0);
-        platform.prepare_render(&ui, &window);
-        let draw_data = ui.render();
-        renderer
-            .render(&mut target, draw_data)
-            .expect("Couldn't render");
-        target.finish().expect("Failed to swap buffers");
-    }
-}
-
-pub fn render_camera(
-    ui: &Ui,
-    display: &Display,
-    renderer: &mut Renderer,
-    camera_data: &Option<CameraData>,
-    texture_id: &mut Option<TextureId>,
-) {
-    if let Some(camera_data) = camera_data {
-        let image_frame = Some(RawImage2d {
-            data: Cow::Owned(camera_data.image_bytes.clone()),
-            width: camera_data.width as u32,
-            height: camera_data.height as u32,
-            format: ClientFormat::U8U8U8,
-        })
-        .unwrap();
-        let gl_texture = Texture2d::new(display.get_context(), image_frame)
-            .expect("Couldn't create new texture");
-        if let Some(tex_id) = texture_id {
-            renderer.textures().replace(*tex_id, Rc::new(gl_texture));
-        } else {
-            *texture_id = Some(renderer.textures().insert(Rc::new(gl_texture)));
-        }
-    }
-
-    if let Some(tex_id) = texture_id {
-        Window::new(im_str!("Camera"))
-            .size([800.0, 600.0], Condition::FirstUseEver)
-            .build(ui, || {
-                ui.text(im_str!("Camera"));
-                Image::new(*tex_id, [640.0, 480.0]).build(&ui);
-            });
-    }
-}
+use camera::Camera;
+use crossbeam::unbounded;
+use std::io;
+use std::thread;
+use window::{SensorData, SensorWindow};
 
 fn main() -> io::Result<()> {
     let (camera_tx, camera_rx) = unbounded();
@@ -180,11 +13,12 @@ fn main() -> io::Result<()> {
     sensor_data.camera = Some(camera_rx);
 
     thread::spawn(move || -> io::Result<()> {
-        let camera = camera::Camera::new(camera_tx);
+        let camera = Camera::new(camera_tx);
         camera.start("0.0.0.0:8001".parse().unwrap())?;
         Ok(())
     });
 
-    render(sensor_data);
+    let window = SensorWindow::new();
+    window.render(sensor_data);
     Ok(())
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,0 +1,193 @@
+use crate::camera::CameraData;
+use crossbeam::Receiver;
+use glium::glutin::{self, Event, WindowEvent};
+use glium::{
+    backend::Facade,
+    texture::{ClientFormat, RawImage2d},
+    Texture2d,
+};
+use glium::{Display, Surface};
+use imgui::{
+    self, im_str, Condition, Context, FontConfig, FontSource, Image, TextureId,
+    Ui, Window,
+};
+use imgui_glium_renderer::Renderer;
+use imgui_winit_support::{HiDpiMode, WinitPlatform};
+use std::borrow::Cow;
+use std::rc::Rc;
+
+pub struct SensorData {
+    pub camera: Option<Receiver<CameraData>>,
+}
+
+impl SensorData {
+    pub fn new() -> Self {
+        Self { camera: None }
+    }
+}
+
+pub struct SensorWindow {
+    pub events_loop: glutin::EventsLoop,
+    pub display: Display,
+    pub imgui: Context,
+    pub platform: WinitPlatform,
+    pub renderer: Renderer,
+    pub font_size: f32,
+}
+
+impl SensorWindow {
+    /// Initializes the window for displaying multiple sensors.
+    pub fn new() -> Self {
+        let events_loop = glutin::EventsLoop::new();
+        let context = glutin::ContextBuilder::new().with_vsync(true);
+        let builder = glutin::WindowBuilder::new()
+            .with_dimensions(glutin::dpi::LogicalSize::new(1920f64, 1080f64));
+        let display = Display::new(builder, context, &events_loop)
+            .expect("Could not create display.");
+        let mut imgui = Context::create();
+        imgui.set_ini_filename(None);
+        let mut platform = WinitPlatform::init(&mut imgui);
+        {
+            let gl_window = display.gl_window();
+            let window = gl_window.window();
+            platform.attach_window(imgui.io_mut(), &window, HiDpiMode::Rounded);
+        }
+        let hidpi_factor = platform.hidpi_factor();
+        let font_size = (13.0 * hidpi_factor) as f32;
+        imgui.fonts().add_font(&[
+            FontSource::DefaultFontData {
+                config: Some(FontConfig {
+                    size_pixels: font_size,
+                    ..FontConfig::default()
+                }),
+            },
+            FontSource::TtfData {
+                data: ttf_noto_sans::REGULAR,
+                size_pixels: font_size,
+                config: Some(FontConfig {
+                    rasterizer_multiply: 1.75,
+                    ..FontConfig::default()
+                }),
+            },
+        ]);
+
+        imgui.io_mut().font_global_scale = (1.0 / hidpi_factor) as f32;
+
+        let renderer = Renderer::init(&mut imgui, &display)
+            .expect("Failed to initialize renderer");
+
+        Self {
+            events_loop,
+            display,
+            imgui,
+            platform,
+            renderer,
+            font_size,
+        }
+    }
+
+    /// Starts the rendering loop for the window. This will check for
+    /// any new data received from the sensors and update any windows
+    /// with new information.
+    pub fn render(self, mut sensor_data: SensorData) {
+        let SensorWindow {
+            mut events_loop,
+            mut platform,
+            display,
+            mut imgui,
+            mut renderer,
+            ..
+        } = self;
+        let gl_window = display.gl_window();
+        let window = gl_window.window();
+        let mut texture_id = None;
+        let mut run = true;
+
+        while run {
+            // Handle any close events for the window.
+            events_loop.poll_events(|event| {
+                platform.handle_event(imgui.io_mut(), &window, &event);
+
+                if let Event::WindowEvent { event, .. } = event {
+                    if let WindowEvent::CloseRequested = event {
+                        run = false;
+                    }
+                }
+            });
+
+            let io = imgui.io_mut();
+            platform
+                .prepare_frame(io, &window)
+                .expect("Failed to start frame.");
+            let ui = imgui.frame();
+
+            // Check for camera data if there is a receiver set up. Currently
+            // this assumes that there is only one sensor. This limitation
+            // should be lifted eventually.
+            if let Some(ref mut camera) = sensor_data.camera {
+                SensorWindow::render_camera_window(
+                    &ui,
+                    &display,
+                    &mut renderer,
+                    &camera.try_recv().ok(),
+                    &mut texture_id,
+                );
+            }
+
+            // Once all the sensor windows are created and update them, we can
+            // now draw them to the screen and start another iteration.
+            let mut target = display.draw();
+            target.clear_color_srgb(0.8, 0.8, 0.8, 1.0);
+            platform.prepare_render(&ui, &window);
+            let draw_data = ui.render();
+            renderer
+                .render(&mut target, draw_data)
+                .expect("Couldn't render");
+            target.finish().expect("Failed to swap buffers");
+        }
+    }
+
+    /// Renders the data received from the camera sensor. This currently
+    /// assumes RGB data format.
+    fn render_camera_window(
+        ui: &Ui,
+        display: &Display,
+        renderer: &mut Renderer,
+        camera_data: &Option<CameraData>,
+        texture_id: &mut Option<TextureId>,
+    ) {
+        // If we've received new camera data, update the texture. We also need
+        // to check if there is an existing texture ahead of time so we can
+        // reuse the texture instead of creating a new one each time.
+        if let Some(camera_data) = camera_data {
+            let image_frame = Some(RawImage2d {
+                data: Cow::Owned(camera_data.image_bytes.clone()),
+                width: camera_data.width as u32,
+                height: camera_data.height as u32,
+                format: ClientFormat::U8U8U8,
+            })
+            .unwrap();
+            let gl_texture = Texture2d::new(display.get_context(), image_frame)
+                .expect("Couldn't create new texture");
+            if let Some(tex_id) = texture_id {
+                renderer.textures().replace(*tex_id, Rc::new(gl_texture));
+            } else {
+                *texture_id =
+                    Some(renderer.textures().insert(Rc::new(gl_texture)));
+            }
+        }
+
+        // We call this each iteration of the SensorWindow, so we need to make
+        // sure we draw the window even if we didn't receive camera data on
+        // this iteration. However, we currently do not draw a window unless
+        // we've received our first sample from the camera.
+        if let Some(tex_id) = texture_id {
+            Window::new(im_str!("Camera"))
+                .size([800.0, 600.0], Condition::FirstUseEver)
+                .build(ui, || {
+                    ui.text(im_str!("Camera"));
+                    Image::new(*tex_id, [640.0, 480.0]).build(&ui);
+                });
+        }
+    }
+}


### PR DESCRIPTION
- To support future sensors, we have to be able to receive data
  separately from the rendering of the window. Data reception for the
  camera now takes place in src/camera.rs and rendering still takes
  place in src/main.rs for now. Expecting rendering to move.
- Channels are now used to send data to the renderer.
- Event loop is now polled to check for close.
- src/window.rs now contains the logic for creating and managing the
  window for displaying sensor information. src/main.rs is now a very
  thin interface.
- Added some docstrings.