### PR TITLE
Moving some responsibilities around for receiving data

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,24 +1,11 @@
 mod camera;
 mod window;
 
-use camera::Camera;
-use crossbeam::unbounded;
 use std::io;
-use std::thread;
-use window::{SensorData, SensorWindow};
+use window::SensorWindow;
 
 fn main() -> io::Result<()> {
-    let (camera_tx, camera_rx) = unbounded();
-    let mut sensor_data = SensorData::new();
-    sensor_data.camera = Some(camera_rx);
-
-    thread::spawn(move || -> io::Result<()> {
-        let camera = Camera::new(camera_tx);
-        camera.start("0.0.0.0:8001".parse().unwrap())?;
-        Ok(())
-    });
-
     let window = SensorWindow::new();
-    window.render(sensor_data);
+    window.render();
     Ok(())
 }


### PR DESCRIPTION
- A sensor window is now expected to hold a receiver to collect data
  versus being passed it in the render function of the Renderable trait.
- The thread for receiving data from sensors is now spawned at the
  sensor and returns a JoinHandler versus having thread spawning happen
  somewhere else.
- The SensorWindow now has a list of sensor windows to render that it
  iterates over. Windows are still manually spawned until we have a
  window used for configuring and instantiating windows.