### PR TITLE
Fixing the LIDAR plot to display correctly

### DIFF
--- a/camera_capt.py
+++ b/camera_capt.py
@@ -1,4 +1,5 @@
 import io
+import math
 import socket
 import struct
 import time
@@ -30,10 +31,9 @@ connection = client_socket.makefile('wb')
 try:
     output = SplitFrames(connection)
     with picamera.PiCamera(resolution='VGA', framerate=30) as camera:
-        time.sleep(2)
         start = time.time()
         camera.start_recording(output, format='mjpeg')
-        camera.wait_recording(30)
+        camera.wait_recording(float("inf"))
         camera.stop_recording()
         # Write the terminating 0-length to the connection to let the
         # server know we're done

--- a/lidar_capt.py
+++ b/lidar_capt.py
@@ -1,0 +1,29 @@
+import socket
+from math import floor
+import struct
+from adafruit_rplidar import RPLidar
+import ctypes
+
+PORT_NAME = '/dev/ttyUSB0'
+lidar = RPLidar(None, PORT_NAME)
+lidar.connect()
+lidar.set_pwm(1023)
+lidar.start_motor()
+
+data_socket = socket.socket()
+data_socket.connect(('192.168.1.204', 8002))
+connection = data_socket.makefile('wb')
+
+scan_data = [0] * 360
+buf = (ctypes.c_float * 360)()
+
+try:
+    for scan in lidar.iter_scans():
+        for (_, angle, distance) in scan:
+            scan_data[min([359, floor(angle)])] = distance
+        buf[:] = scan_data
+        connection.write(buf)
+except:
+    print("Stopping collection.")
+lidar.stop()
+lidar.disconnect()

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -159,9 +159,9 @@ pub struct CameraConfig {
 
 impl CameraConfig {
     pub fn new() -> Self {
-        Self {
-            camera_ip: ImString::with_capacity(20),
-        }
+        let mut camera_ip = ImString::new("0.0.0.0:8001");
+        camera_ip.reserve_exact(10);
+        Self { camera_ip }
     }
 
     pub fn render_camera_modal(


### PR DESCRIPTION
- The LIDAR plot now displays correctly and should work to certain
  scales. At the moment, the scale is hardcoded but we should think of a
  better way to handle it. A TODO has been left as a reminder.
- The config windows now provide default listening IP addresses for ease
  in testing. At some point, this information should be loaded from a
  configuration file.
- Adding the lidar_capt.py script which is used to send angle and
  distance information received from the RPLIDAR.
- Updating the camera_capt.py script to send data forever versus running
  for 30 seconds.