### PR TITLE
Structure renames and various performance improvements

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -1,5 +1,5 @@
 use crate::camera::CameraConfig;
-use crate::gps::GPSConfig;
+use crate::gps::GpsConfig;
 use crate::lidar::LidarConfig;
 use glium::glutin::{self, Event, WindowEvent};
 use glium::{Display, Surface};
@@ -82,7 +82,7 @@ impl SensorWindow {
         let config_windows: Vec<Box<dyn Modal>> = vec![
             Box::new(CameraConfig::new()),
             Box::new(LidarConfig::new()),
-            Box::new(GPSConfig::new()),
+            Box::new(GpsConfig::new()),
         ];
 
         Self {


### PR DESCRIPTION
- For consistency with Rust naming convention, all instances of GPS* have been
  renamed Gps*.
- Changed the GpsWindow from holding the raw bytes of the image to an RgbImage
  so that drawing points only requires a single draw per receive versus drawing
  all received points each iteration.