### PR TITLE
Changing from full IP address to port number

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -182,23 +182,23 @@ impl Renderable for CameraWindow {
 }
 
 pub struct CameraConfig {
-    camera_ip: ImString,
+    camera_port: ImString,
     video_format_list: Vec<ImString>,
     video_format_item: usize,
 }
 
 impl CameraConfig {
     pub fn new() -> Self {
-        let mut camera_ip = ImString::new("0.0.0.0:8001");
+        let mut camera_port = ImString::new("8001");
         let video_format_list: Vec<ImString> = VideoFormat::iter()
             .map(|vf| {
                 let vf_str: &str = vf.as_ref();
                 ImString::new(vf_str)
             })
             .collect();
-        camera_ip.reserve_exact(10);
+        camera_port.reserve_exact(10);
         Self {
-            camera_ip,
+            camera_port,
             video_format_item: 0,
             video_format_list,
         }
@@ -215,7 +215,7 @@ impl Modal for CameraConfig {
         ui.popup_modal(im_str!("Camera Configuration"))
             .flags(WindowFlags::ALWAYS_AUTO_RESIZE)
             .build(|| {
-                ui.input_text(im_str!("Listen Address"), &mut self.camera_ip)
+                ui.input_text(im_str!("Listen Port"), &mut self.camera_port)
                     .build();
 
                 // For some reason, the combo box takes a slice of references, so
@@ -239,8 +239,7 @@ impl Modal for CameraConfig {
                     let camera = Camera::new(camera_tx);
                     join_handles.push(
                         camera.start(
-                            self.camera_ip
-                                .to_string()
+                            format!("0.0.0.0:{}", self.camera_port.to_string())
                                 .parse()
                                 .expect("couldn't parse IP address"),
                             video_format,

--- a/src/gps.rs
+++ b/src/gps.rs
@@ -338,14 +338,14 @@ impl Renderable for GpsWindow {
 }
 
 pub struct GpsConfig {
-    gps_ip: ImString,
+    gps_port: ImString,
 }
 
 impl GpsConfig {
     pub fn new() -> Self {
-        let mut gps_ip = ImString::new("0.0.0.0:8003");
-        gps_ip.reserve_exact(10);
-        Self { gps_ip }
+        let mut gps_port = ImString::new("8003");
+        gps_port.reserve_exact(10);
+        Self { gps_port }
     }
 }
 
@@ -359,15 +359,14 @@ impl Modal for GpsConfig {
         ui.popup_modal(im_str!("GPS Configuration"))
             .flags(WindowFlags::ALWAYS_AUTO_RESIZE)
             .build(|| {
-                ui.input_text(im_str!("Listen Address"), &mut self.gps_ip)
+                ui.input_text(im_str!("Listen Port"), &mut self.gps_port)
                     .build();
                 if ui.button(im_str!("Create Sensor Window"), [0.0, 0.0]) {
                     let (gps_tx, gps_rx) = unbounded();
                     let gps = Gps::new(gps_tx);
                     join_handles.push(
                         gps.start(
-                            self.gps_ip
-                                .to_string()
+                            format!("0.0.0.0:{}", self.gps_port.to_string())
                                 .parse()
                                 .expect("couldn't parse IP address"),
                         ),

--- a/src/lidar.rs
+++ b/src/lidar.rs
@@ -143,14 +143,14 @@ impl Renderable for LidarWindow {
 }
 
 pub struct LidarConfig {
-    lidar_ip: ImString,
+    lidar_port: ImString,
 }
 
 impl LidarConfig {
     pub fn new() -> Self {
-        let mut lidar_ip = ImString::new("0.0.0.0:8002");
-        lidar_ip.reserve_exact(10);
-        Self { lidar_ip }
+        let mut lidar_port = ImString::new("8002");
+        lidar_port.reserve_exact(10);
+        Self { lidar_port }
     }
 }
 
@@ -164,15 +164,14 @@ impl Modal for LidarConfig {
         ui.popup_modal(im_str!("LIDAR Configuration"))
             .flags(WindowFlags::ALWAYS_AUTO_RESIZE)
             .build(|| {
-                ui.input_text(im_str!("Listen Address"), &mut self.lidar_ip)
+                ui.input_text(im_str!("Listen Port"), &mut self.lidar_port)
                     .build();
                 if ui.button(im_str!("Create Sensor Window"), [0.0, 0.0]) {
                     let (lidar_tx, lidar_rx) = unbounded();
                     let lidar = Lidar::new(lidar_tx);
                     join_handles.push(
                         lidar.start(
-                            self.lidar_ip
-                                .to_string()
+                            format!("0.0.0.0:{}", self.lidar_port.to_string())
                                 .parse()
                                 .expect("couldn't parse IP address"),
                         ),


### PR DESCRIPTION
- Since we expect data to come from a separate device, there's little
  reason to include the 0.0.0.0 listen address. The user now just needs
  to specify the port to listen on.